### PR TITLE
Implemented polling frequency and max message behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 terraform.tfvars
 terraform.tfstate*
 .terraform*
+.idea/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.0
+ - added option to configure polling frequency and number of messages to fetch in one batch to be able to manage AWS SQS cost
+
 # 2.0.0
  - added support for Logstash 6.x.
 

--- a/logstash-input-s3sqs.gemspec
+++ b/logstash-input-s3sqs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-s3sqs'
-  s.version         = '2.0.0'
+  s.version         = '2.1.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Get logs from AWS s3 buckets as issued by an object-created event via sqs."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Copied polling frequency and max message behavior from logstash-input-sqs plugin (https://github.com/logstash-plugins/logstash-input-sqs/blob/master/lib/logstash/inputs/sqs.rb) to fetch messages from AWS SQS queue more efficiently and save costs thereby.

![aws-sqs-empty-receive-drop-after-better-polling-frequency-setup](https://user-images.githubusercontent.com/24251091/51310396-df6ce780-1a46-11e9-85bd-2da1b17270b0.png)
